### PR TITLE
Switch doc generation to official GitHub pages Actions

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,9 @@ jobs:
   build-doc:
     runs-on: ubuntu-latest
 
+    environment:
+      name: github-pages
+
     steps:
       - uses: actions/checkout@v4
       - uses: pdm-project/setup-pdm@v4

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,10 +30,6 @@ jobs:
     environment:
       name: github-pages
 
-    permissions:
-        pages: write
-        id-token: write
-
     steps:
       - uses: actions/checkout@v4
       - uses: pdm-project/setup-pdm@v4
@@ -43,8 +39,6 @@ jobs:
         run: |
           pdm install --group doc
           cd docs && pdm run mkdocs build
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,12 +1,6 @@
 name: Documentation
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "*.md"
-      - docs/**
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           pdm install --group doc
           cd docs && pdm run mkdocs build
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,21 +9,37 @@ on:
       - docs/**
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production
+# deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-doc:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: pdm-project/setup-pdm@v2
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v4
         with:
           python-version: 3.10.5
       - name: Build pages
         run: |
           pdm install --group doc
           cd docs && pdm run mkdocs build
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/site
+          path: './docs/site'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,6 +30,10 @@ jobs:
     environment:
       name: github-pages
 
+    permissions:
+        pages: write
+        id-token: write
+
     steps:
       - uses: actions/checkout@v4
       - uses: pdm-project/setup-pdm@v4


### PR DESCRIPTION
Our current Actions build a site but something is wrong with how it's being deployed.

Adapted from https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow