### PR TITLE
Move to publicly accessible URL for Docker image

### DIFF
--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -110,7 +110,7 @@ def build_docker(
         (
             "--tag",
             docker_tag,
-            "ssh://git@github.com/quant-aq/aeromancy.git#v0.1.0:docker",
+            "https://github.com/quant-aq/aeromancy.git#v0.1.0:docker",
         ),
     )
     docker_command = " ".join(docker_commmand_pieces)


### PR DESCRIPTION
Most people don't have ssh access to the public Aeromancy repo, so we shouldn't use it here.