### PR TITLE
Add docs for --extra-env-var

### DIFF
--- a/docs/docs/customizing.md
+++ b/docs/docs/customizing.md
@@ -23,6 +23,11 @@ adjust:
 - **Extra Debian packages:** (outside of those included by Aeromancy), you may
   want to bake them into the `pdm go` script with `--extra-debian-package='...'`
   (specify the flag once per package name).
+- **Extra environment variables:** If your code needs information in environment
+  variables (e.g., API keys and other credentials), you can pass tell Aeromancy
+  to pass these through to container with `--extra-env-var` (specify the flag
+  once per variable). Use these sparingly, as they could make steps using these
+  variables harder to reproduce and are **not** tracked by Aeromancy.
 
 ## Filesystem layout
 


### PR DESCRIPTION
It's a previously undocumented feature, but been implemented and used internally for a bit: https://github.com/quant-aq/aeromancy/blob/3694a0378a61b6f995f0a122666c42f40c5089bf/src/aeromancy/click_options.py#L22