### PR TITLE
Support associating tasks with tags, minor cleanups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,25 +2,21 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.4.0'
+    rev: 'v4.6.0'
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-added-large-files
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.289'
+    rev: 'v0.5.5'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
-
-  - repo: https://github.com/psf/black
-    rev: '23.9.1'
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/google/keep-sorted
-    rev: v0.1.0
+    rev: v0.4.0
     hooks:
       - id: keep-sorted
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,9 @@
 # This creates an image for running Aeromancy tasks, used by runner.py.
 # See Aeromancy scaffolding docs for an overview of how this fits together.
 
+# NOTE: If this file is updated, make a new Aeromancy release and point
+# aeromancy.runner.build_docker to use it.
+
 # This Python version must match a version required by pyproject.toml.
 FROM python:3.10.5-bullseye
 # To set this in Aeromancy, pass --extra-debian-package to `pdm go`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,13 @@ line-length = 88
 target-version = ["py310"]
 
 [tool.ruff]
+src = ["src"]
 line-length = 88
+extend-exclude = ["tests/fixtures", "__pycache__"]
+target-version = "py310"
+namespace-packages = ["docs", "tasks"]
+
+[tool.ruff.lint]
 select = [
   # keep-sorted start
   "ASYNC", # flake8-async
@@ -148,6 +154,7 @@ ignore = [
   # keep-sorted start
   "D203",   # one-blank-line-before-class (incompatible with D211)
   "D213",   # multi-line-summary-second-line (incompatible with D212)
+  "D413",   # blank-line-after-last-section (not needed for numpy conventions)
   "PGH003", # blanket-type-ignore: Use specific rule codes when ignoring type issues (no always feasible)
   "RET504", # unnecessary-assign: Sometimes worth doing for readability
   "RET505", # superfluous-else-return: Currently has a bug
@@ -159,15 +166,11 @@ ignore = [
   "TRY003", # raise-vanilla-args: Not for prototyping, not always an error
   # keep-sorted end
 ]
-src = ["src"]
-extend-exclude = ["tests/fixtures", "__pycache__"]
-target-version = "py310"
-namespace-packages = ["docs", "tasks"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["S101"]  # Allow using asserts in tests
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["aeromancy"]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,10 @@ doc.shell = "cd docs && mkdocs serve -a localhost:8030"
 lint.help = "Run linters over all files"
 lint.cmd = "pre-commit run --all-files"
 
+# PDM hook to automatically sort dependencies when they change.
+# "true" is there since GitHub Actions will fail if this returns a non-zero exit code.
+post_install.shell = "pre-commit run keep-sorted --files pyproject.toml > /dev/null 2> /dev/null; true"
+
 #
 # Aeromancy-specific scripts.
 #

--- a/src/aeromancy/action.py
+++ b/src/aeromancy/action.py
@@ -1,6 +1,7 @@
 """Action objects are the core piece of trackable computation in Aeromancy."""
 
 from .artifacts import WandbArtifactName
+from .runtime_environment import get_runtime_environment
 from .tracker import Tracker
 from .wandb_tracker import WandbTracker
 
@@ -38,6 +39,7 @@ class Action:
         self.parents = parents
         self._tracker_class = WandbTracker
         self._project_name = None
+        self._tags = None
 
     def outputs(self) -> list[str]:
         """Describe what this `Action` will produce after being run.
@@ -132,6 +134,8 @@ class Action:
         """Set properties that we won't know until ActionRunner time."""
         # TODO: With some refactoring, this could be combined with
         # _set_buildtime_properties
+        if get_runtime_environment().debug_mode:
+            print(f"DEBUG _set_runtime_properties: {tags=}")
         self._tags = tags
 
     skip = property(lambda self: self._skip, doc="Whether this action should be run")

--- a/src/aeromancy/action.py
+++ b/src/aeromancy/action.py
@@ -9,7 +9,8 @@ class Action:
     """A specific piece of work to track.
 
     This includes the code to run, artifacts it depends on, and artifacts it
-    produces. For organizational purposes, they can fill in class variables:
+    produces. For organizational purposes, subclasses can fill in class
+    variables:
 
     - `job_type`
     - `job_group`

--- a/src/aeromancy/action.py
+++ b/src/aeromancy/action.py
@@ -78,6 +78,7 @@ class Action:
             job_group=self.job_group,
             config=self.config,
             project_name=self._project_name,
+            tags=self._tags,
         ) as tracker:
             self.run(tracker)
 
@@ -122,9 +123,15 @@ class Action:
             ]
         return (full_inputs, full_outputs)
 
-    def _set_runtime_properties(self, project_name: str, skip: bool):
-        """Set properties that we won't know until we're ready to run."""
+    def _set_buildtime_properties(self, project_name: str, skip: bool):
+        """Set properties that we won't know until ActionBuilder time."""
         self._skip = skip
         self._project_name = project_name
+
+    def _set_runtime_properties(self, tags: list[str] | None = None):
+        """Set properties that we won't know until ActionRunner time."""
+        # TODO: With some refactoring, this could be combined with
+        # _set_buildtime_properties
+        self._tags = tags
 
     skip = property(lambda self: self._skip, doc="Whether this action should be run")

--- a/src/aeromancy/action.py
+++ b/src/aeromancy/action.py
@@ -133,7 +133,7 @@ class Action:
         self._skip = skip
         self._project_name = project_name
 
-    def _set_runtime_properties(self, tags: list[str] | None = None):
+    def _set_runtime_properties(self, tags: set[str] | None = None):
         """Set properties that we won't know until ActionRunner time."""
         # TODO: With some refactoring, this could be combined with
         # _set_buildtime_properties

--- a/src/aeromancy/action_builder.py
+++ b/src/aeromancy/action_builder.py
@@ -69,7 +69,7 @@ class ActionBuilder:
         -------
             The `Action` passed as `action`, with additional run state added
         """
-        action._set_runtime_properties(self._project_name, skip=skip)
+        action._set_buildtime_properties(self._project_name, skip=skip)
         actions.append(action)
         return action
 

--- a/src/aeromancy/action_runner.py
+++ b/src/aeromancy/action_runner.py
@@ -95,7 +95,7 @@ class ActionRunner(TaskLoader2):
         """
         self.actions = actions
         self.job_name_filter = None
-        self.job_tags = []
+        self.job_tags = set()
 
     @override
     def load_doit_config(self):
@@ -228,7 +228,7 @@ class ActionRunner(TaskLoader2):
             raise SystemExit
 
         if tags:
-            self.job_tags = tags.split(",")
+            self.job_tags = set(tags.split(","))
 
         if get_runtime_environment().dev_mode:
             console.rule(

--- a/src/aeromancy/action_runner.py
+++ b/src/aeromancy/action_runner.py
@@ -185,10 +185,10 @@ class ActionRunner(TaskLoader2):
 
     def run_actions(
         self,
-        only: str | None,
+        only: set[str] | None,
         graph: bool,
         list_actions: bool,
-        tags: str | None,
+        tags: set[str] | None,
         **unused_kwargs,
     ):
         """Run the stored `Action`s using pydoit.
@@ -212,7 +212,7 @@ class ActionRunner(TaskLoader2):
         if only:
 
             def job_name_filter(job_name):
-                for job_name_substring in only.split(","):
+                for job_name_substring in only:
                     if job_name_substring.strip() in job_name:
                         return True
                 return False
@@ -227,8 +227,7 @@ class ActionRunner(TaskLoader2):
             self._list_actions()
             raise SystemExit
 
-        if tags:
-            self.job_tags = set(tags.split(","))
+        self.job_tags = tags
 
         if get_runtime_environment().dev_mode:
             console.rule(

--- a/src/aeromancy/aeroview.py
+++ b/src/aeromancy/aeroview.py
@@ -8,6 +8,7 @@ or:
 
     shell> pdm aeroview <Weights and Biases artifact name>
 """
+
 import subprocess
 from pathlib import Path
 

--- a/src/aeromancy/artifacts.py
+++ b/src/aeromancy/artifacts.py
@@ -192,10 +192,7 @@ class WandbArtifactName(msgspec.Struct):
         ):
             return False
 
-        if self.artifact_name != other_artifact_name.artifact_name:
-            return False
-
-        return True
+        return self.artifact_name == other_artifact_name.artifact_name
 
     def incorporate_overrides(self):
         """Incorporate artifact version overrides.

--- a/src/aeromancy/click_options.py
+++ b/src/aeromancy/click_options.py
@@ -1,4 +1,5 @@
 """Groups of Click options for the main Aeromancy CLI interface."""
+
 import functools
 
 import rich_click as click
@@ -62,10 +63,10 @@ def runner_click_options(function):
     @click.option(
         "--extra-debian-package",
         "extra_debian_packages",
-        metavar="PKGS",
+        metavar="PKG",
         multiple=True,
         help=(
-            "Names of Debian packages to include in the Docker image in addition to "
+            "Name of a Debian package to include in the Docker image in addition to "
             "standard packages required by Aeromancy. Specify this option once per "
             "extra package. You should generally not need to change this, but it may "
             "be set in pdm scripts when setting up a project."
@@ -74,10 +75,10 @@ def runner_click_options(function):
     @click.option(
         "--extra-env-var",
         "extra_env_vars",
-        metavar="VARS",
+        metavar="VAR",
         multiple=True,
         help=(
-            "Extra environment variables to passthrough to Aeromancy. Specify this "
+            "Extra environment variable to passthrough to Aeromancy. Specify this "
             "option once per variable. You should generally not need to change this, "
             "but it may be set in pdm scripts when setting up a project."
         ),
@@ -99,8 +100,8 @@ def runner_click_options(function):
         "aeromain_path",
         default="src/main.py",
         metavar="PATH",
-        # To minimize confusion since this is only intended for
-        # debugging/testing Aeromancy itself.
+        # This is only intended for debugging/testing Aeromancy itself so hidden
+        # to minimize confusion.
         hidden=True,
         help="Set an alternate Aeromain file to run.",
     )
@@ -137,6 +138,13 @@ def aeromancy_click_options(function):
         "--list",
         is_flag=True,
         help="If set: show a list of all job names and exit.",
+    )
+    @click.option(
+        "--tags",
+        "tags",
+        metavar="TAGS",
+        help="Comma-separated tags to add to each task launched. These tags are purely "
+        "for organizational purposes.",
     )
     @runner_click_options
     @functools.wraps(function)

--- a/src/aeromancy/click_options.py
+++ b/src/aeromancy/click_options.py
@@ -10,7 +10,12 @@ click.rich_click.OPTION_GROUPS = {
     "main.py": [
         {
             "name": "Task runner options",
-            "options": ["--only", "--graph", "--list-actions"],
+            "options": [
+                "--only",
+                "--graph",
+                "--list-actions",
+                "--tags",
+            ],
         },
         {
             "name": "Aeromancy runtime options",

--- a/src/aeromancy/export_utils.py
+++ b/src/aeromancy/export_utils.py
@@ -6,6 +6,7 @@ sometimes you just need to pull an artifact out and analyze it in a Notebook.
 Warning: Here be dragons (*cough* hacks). Code in this module relies on
 Aeromancy internals and is subject to change.
 """
+
 import os
 from collections.abc import Sequence
 from pathlib import Path

--- a/src/aeromancy/fake_tracker.py
+++ b/src/aeromancy/fake_tracker.py
@@ -84,6 +84,7 @@ class FakeTracker(Tracker):
         config: dict | None = None,
         job_type: str | None = None,
         job_group: str | None = None,
+        tags: set[str] | None = None,
     ):
         Tracker.__init__(
             self,
@@ -91,6 +92,7 @@ class FakeTracker(Tracker):
             config=config,
             job_type=job_type,
             job_group=job_group,
+            tags=tags,
         )
 
         self.cache_root_path = Path("~/FakeCache").expanduser().resolve()

--- a/src/aeromancy/rerun.py
+++ b/src/aeromancy/rerun.py
@@ -6,6 +6,7 @@ Run with:
 
 After it creates a Git repo for that run, it will provide instructions for how to rerun.
 """
+
 import subprocess
 import tempfile
 from dataclasses import dataclass

--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -111,7 +111,8 @@ def build_docker(
         (
             "--tag",
             docker_tag,
-            # The version tag should be updated whenever Dockerfile changes.
+            # The version tag should be updated whenever ../../docker/Dockerfile
+            # changes.
             "https://github.com/quant-aq/aeromancy.git#v0.2.2:docker",
         ),
     )
@@ -119,7 +120,7 @@ def build_docker(
 
     console.log(f"Running {docker_command!r}", style="info")
     docker_status, docker_output = subprocess.getstatusoutput(  # noqa: S605
-        docker_command,
+        docker_commmand_pieces,
     )
     if docker_status:
         console.log(f"Docker output: {docker_output}", style="error")

--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -49,7 +49,7 @@ console = Console(theme=custom_theme)
 def interactive(command_pieces: list[str]) -> None:
     """Run interactive shell commands."""
     formatted_pieces = shlex.join(command_pieces)
-    console.log(f"Running {formatted_pieces}", style="info")
+    console.log(f"[bold]Running:[/bold] {formatted_pieces}", style="info")
     exit_code = subprocess.call(
         command_pieces,
         stdout=sys.stdout,

--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -8,6 +8,7 @@ be setup in pyproject.toml.
 """
 
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -45,17 +46,17 @@ custom_theme = Theme({"info": "dim cyan", "warning": "magenta", "error": "bold r
 console = Console(theme=custom_theme)
 
 
-def interactive(command: str) -> None:
+def interactive(command_pieces: list[str]) -> None:
     """Run interactive shell commands."""
-    console.log(f"Running {command.strip()!r}", style="info")
-    exit_code = subprocess.call(  # noqa: S602
-        command,
-        shell=True,
+    formatted_pieces = shlex.join(command_pieces)
+    console.log(f"Running {formatted_pieces}", style="info")
+    exit_code = subprocess.call(
+        command_pieces,
         stdout=sys.stdout,
         stderr=subprocess.STDOUT,
     )
     if exit_code:
-        console.log(f"Exit code {exit_code} for {command!r}", style="warning")
+        console.log(f"Exit code {exit_code} for {formatted_pieces}", style="warning")
 
 
 def check_git_state() -> None:
@@ -90,12 +91,13 @@ def build_docker(
 
     Returns the hash of the Docker image.
     """
+    ssh_auth_sock = os.environ.get("SSH_AUTH_SOCK", "")
     docker_commmand_pieces = [
         "docker",
         "buildx",
         "build",
         # Forward SSH authorization so we can access private repos.
-        "--ssh=default=$SSH_AUTH_SOCK",
+        f"--ssh=default={ssh_auth_sock}",
         # Add local project (i.e., not Aeromancy's repo) as a build context so
         # we can copy project-specific files to the image.
         "--build-context",
@@ -116,15 +118,29 @@ def build_docker(
             "https://github.com/quant-aq/aeromancy.git#v0.2.2:docker",
         ),
     )
-    docker_command = " ".join(docker_commmand_pieces)
 
-    console.log(f"Running {docker_command!r}", style="info")
-    docker_status, docker_output = subprocess.getstatusoutput(  # noqa: S605
-        docker_commmand_pieces,
+    console.log(
+        f"[bold]Building Docker image:[/bold] {shlex.join(docker_commmand_pieces)}",
+        style="info",
     )
+    try:
+        docker_output = subprocess.check_output(
+            docker_commmand_pieces,
+            text=True,
+            stderr=subprocess.STDOUT,
+        )
+        docker_status = 0
+    except subprocess.CalledProcessError as cpe:
+        docker_output = cpe.output
+        docker_status = cpe.returncode
+
+    if docker_status or not quiet:
+        console.log(
+            f"Docker output:\n{docker_output}",
+            style="error" if docker_status else "info",
+        )
     if docker_status:
-        console.log(f"Docker output: {docker_output}", style="error")
-        raise SystemExit(f"Docker exited with {docker_status}")
+        raise SystemExit(f"Docker image building failed with exit code {docker_status}")
     return docker_output.strip()
 
 
@@ -181,13 +197,24 @@ def store_environment_variables(
 def run_docker(
     env_filename: str,
     docker_tag: str,
-    docker_subcommand: str,
-    extra_docker_run_args: str,
+    docker_subcommand_pieces: list[str],
+    extra_docker_run_args: list[str],
 ) -> None:
     """Run `docker run` with specified arguments."""
+    local_cache_path = Path("~/Cache").expanduser()
     interactive(
-        f"docker run --env-file {env_filename} -v ~/Cache:/root/Cache "
-        f"{extra_docker_run_args} -it {docker_tag} {docker_subcommand}",
+        [
+            "docker",
+            "run",
+            "--env-file",
+            env_filename,
+            "-v",
+            f"{local_cache_path!s}:/root/Cache",
+            *extra_docker_run_args,
+            "-it",
+            docker_tag,
+            *docker_subcommand_pieces,
+        ],
     )
 
 
@@ -202,7 +229,7 @@ def run_docker(
 def main(
     debug_shell: bool,
     dev: bool,
-    extra_docker_run_args: str,
+    extra_docker_run_args: list[str],
     extra_debian_packages: list[str],
     extra_env_vars: list[str],
     artifact_overrides: list[str],
@@ -233,6 +260,11 @@ def main(
             extra_debian_packages=extra_debian_packages,
             quiet=not debug,
         )
+        if debug:
+            # Building Docker images in debug mode makes it tough to determine
+            # the image hash, so we'll set it to a special value.
+            # TODO: Parse Docker image hash in these cases?
+            docker_hash = "debug_docker_hash"
     env_filename = store_environment_variables(
         git_ref=git_ref,
         docker_hash=docker_hash,
@@ -242,18 +274,29 @@ def main(
         extra_env_vars=extra_env_vars,
     )
 
-    formatted_extra_cmdline_args = " ".join(extra_cmdline_args)
     if debug_shell:
-        docker_subcommand = f"/bin/sh {formatted_extra_cmdline_args}"
+        docker_subcommand_pieces = [
+            "/bin/sh",
+            *extra_cmdline_args,
+        ]
     else:
-        docker_subcommand = (
-            f"pdm run python {aeromain_path} {formatted_extra_cmdline_args}"
-        )
+        docker_subcommand_pieces = [
+            "pdm",
+            "run",
+            "python",
+            aeromain_path,
+            *extra_cmdline_args,
+        ]
 
     if dev:
-        interactive(docker_subcommand)
+        interactive(docker_subcommand_pieces)
     else:
-        run_docker(env_filename, docker_tag, docker_subcommand, extra_docker_run_args)
+        run_docker(
+            env_filename,
+            docker_tag,
+            docker_subcommand_pieces,
+            extra_docker_run_args,
+        )
 
 
 if __name__ == "__main__":

--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -209,7 +209,7 @@ def run_docker(
             "--env-file",
             env_filename,
             "-v",
-            f"{local_cache_path!s}:/root/Cache",
+            f"{local_cache_path}:/root/Cache",
             *extra_docker_run_args,
             "-it",
             docker_tag,

--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -6,6 +6,7 @@ code properly.
 You shouldn't ever need to run or call this directly -- the "pdm go" pdm script should
 be setup in pyproject.toml.
 """
+
 import os
 import subprocess
 import sys
@@ -47,9 +48,9 @@ console = Console(theme=custom_theme)
 def interactive(command: str) -> None:
     """Run interactive shell commands."""
     console.log(f"Running {command.strip()!r}", style="info")
-    exit_code = subprocess.call(
+    exit_code = subprocess.call(  # noqa: S602
         command,
-        shell=True,  # noqa: S602
+        shell=True,
         stdout=sys.stdout,
         stderr=subprocess.STDOUT,
     )
@@ -110,13 +111,16 @@ def build_docker(
         (
             "--tag",
             docker_tag,
+            # The version tag should be updated whenever Dockerfile changes.
             "https://github.com/quant-aq/aeromancy.git#v0.1.0:docker",
         ),
     )
     docker_command = " ".join(docker_commmand_pieces)
 
     console.log(f"Running {docker_command!r}", style="info")
-    docker_status, docker_output = subprocess.getstatusoutput(docker_command)
+    docker_status, docker_output = subprocess.getstatusoutput(  # noqa: S605
+        docker_command,
+    )
     if docker_status:
         console.log(f"Docker output: {docker_output}", style="error")
         raise SystemExit(f"Docker exited with {docker_status}")

--- a/src/aeromancy/struct.py
+++ b/src/aeromancy/struct.py
@@ -1,4 +1,5 @@
 """Extended version of `msgspec.Struct` with easier serialization and validation."""
+
 import json
 import tempfile
 from pathlib import Path

--- a/src/aeromancy/tracker.py
+++ b/src/aeromancy/tracker.py
@@ -36,6 +36,7 @@ class Tracker(ABC):
         config: dict | None = None,
         job_type: str | None = None,
         job_group: str | None = None,
+        tags: set[str] | None = None,
     ):
         """Create a Tracker.
 
@@ -46,6 +47,8 @@ class Tracker(ABC):
                 job_group
                     job_type
                         (individual run)
+
+        In addition, a task may be associated with any number of tags.
 
         Parameters
         ----------
@@ -61,11 +64,14 @@ class Tracker(ABC):
         job_group, optional
             Typically used to describe the general goal of a group of tasks
             (e.g., "build", "model")
+        tags, optional
+            List of additional tags (strings) to associate with the task.
         """
         self.project_name = project_name
         self.config = config
         self.job_type = job_type
         self.job_group = job_group
+        self.tags = tags
 
     @abstractmethod
     def __enter__(self):

--- a/src/aeromancy/tracker.py
+++ b/src/aeromancy/tracker.py
@@ -71,7 +71,7 @@ class Tracker(ABC):
         self.config = config
         self.job_type = job_type
         self.job_group = job_group
-        self.tags = tags
+        self.tags = tags or set()
 
     @abstractmethod
     def __enter__(self):

--- a/src/aeromancy/wandb_tracker.py
+++ b/src/aeromancy/wandb_tracker.py
@@ -34,8 +34,6 @@ class WandbTracker(Tracker):
         tags: set[str] | None = None,
         quiet: bool = True,
     ):
-        if get_runtime_environment().debug_mode:
-            print(f"DEBUG: top of WandbTracker {tags=}")
         Tracker.__init__(
             self,
             project_name=project_name,
@@ -52,12 +50,8 @@ class WandbTracker(Tracker):
         # For "https://github.com/x/y.git", we'd pull out "y" as the job name
         job_name = runtime_environment.git_repo_name
 
-        if runtime_environment.debug_mode:
-            print(f"DEBUG: WandbTracker {self.tags=}")
         tags = self.tags or []
         tags.insert(0, f"git/{runtime_environment.git_branch}")
-        if runtime_environment.debug_mode:
-            print(f"DEBUG: WandbTracker {tags=}")
 
         # Run wandb init with our extra tracking data.
         notes = f"{runtime_environment.git_message} (git message for {git_ref[:6]})"

--- a/src/aeromancy/wandb_tracker.py
+++ b/src/aeromancy/wandb_tracker.py
@@ -34,6 +34,8 @@ class WandbTracker(Tracker):
         tags: set[str] | None = None,
         quiet: bool = True,
     ):
+        if get_runtime_environment().debug_mode:
+            print(f"DEBUG: top of WandbTracker {tags=}")
         Tracker.__init__(
             self,
             project_name=project_name,
@@ -50,8 +52,12 @@ class WandbTracker(Tracker):
         # For "https://github.com/x/y.git", we'd pull out "y" as the job name
         job_name = runtime_environment.git_repo_name
 
+        if runtime_environment.debug_mode:
+            print(f"DEBUG: WandbTracker {self.tags=}")
         tags = self.tags or []
         tags.insert(f"git/{runtime_environment.git_branch}")
+        if runtime_environment.debug_mode:
+            print(f"DEBUG: WandbTracker {tags=}")
 
         # Run wandb init with our extra tracking data.
         notes = f"{runtime_environment.git_message} (git message for {git_ref[:6]})"

--- a/src/aeromancy/wandb_tracker.py
+++ b/src/aeromancy/wandb_tracker.py
@@ -2,6 +2,7 @@
 
 Weights and Biases is used to track runs and S3 to store artifacts.
 """
+
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,7 @@ class WandbTracker(Tracker):
         config: dict | None = None,
         job_type: str | None = None,
         job_group: str | None = None,
+        tags: set[str] | None = None,
         quiet: bool = True,
     ):
         Tracker.__init__(
@@ -38,6 +40,7 @@ class WandbTracker(Tracker):
             config=config,
             job_type=job_type,
             job_group=job_group,
+            tags=tags,
         )
 
         self.quiet = quiet
@@ -47,6 +50,9 @@ class WandbTracker(Tracker):
         # For "https://github.com/x/y.git", we'd pull out "y" as the job name
         job_name = runtime_environment.git_repo_name
 
+        tags = self.tags or []
+        tags.insert(f"git/{runtime_environment.git_branch}")
+
         # Run wandb init with our extra tracking data.
         notes = f"{runtime_environment.git_message} (git message for {git_ref[:6]})"
         wandb_run = wandb.init(
@@ -55,7 +61,7 @@ class WandbTracker(Tracker):
             job_type=job_type,
             group=job_group,
             notes=notes,
-            tags=[f"git/{runtime_environment.git_branch}"],
+            tags=tags,
             settings=wandb.Settings(
                 job_name=job_name,
                 git_commit=git_ref,

--- a/src/aeromancy/wandb_tracker.py
+++ b/src/aeromancy/wandb_tracker.py
@@ -50,8 +50,7 @@ class WandbTracker(Tracker):
         # For "https://github.com/x/y.git", we'd pull out "y" as the job name
         job_name = runtime_environment.git_repo_name
 
-        tags = self.tags or []
-        tags.insert(0, f"git/{runtime_environment.git_branch}")
+        self.tags.add(f"git/{runtime_environment.git_branch}")
 
         # Run wandb init with our extra tracking data.
         notes = f"{runtime_environment.git_message} (git message for {git_ref[:6]})"
@@ -61,7 +60,7 @@ class WandbTracker(Tracker):
             job_type=job_type,
             group=job_group,
             notes=notes,
-            tags=tags,
+            tags=self.tags,
             settings=wandb.Settings(
                 job_name=job_name,
                 git_commit=git_ref,

--- a/src/aeromancy/wandb_tracker.py
+++ b/src/aeromancy/wandb_tracker.py
@@ -55,7 +55,7 @@ class WandbTracker(Tracker):
         if runtime_environment.debug_mode:
             print(f"DEBUG: WandbTracker {self.tags=}")
         tags = self.tags or []
-        tags.insert(f"git/{runtime_environment.git_branch}")
+        tags.insert(0, f"git/{runtime_environment.git_branch}")
         if runtime_environment.debug_mode:
             print(f"DEBUG: WandbTracker {tags=}")
 

--- a/src/bogus_aeromain.py
+++ b/src/bogus_aeromain.py
@@ -6,9 +6,8 @@ This is enough to test both `--dev` mode. You can launch it with something like:
 
 Beyond that, flags are as they would be for a normal `pdm go` in an Aeromancy
 project repo.
-
-TODO: Full Docker integration doesn't currently work.
 """
+
 from pathlib import Path
 
 import rich_click as click

--- a/tests/test_aeromancy_artifacts.py
+++ b/tests/test_aeromancy_artifacts.py
@@ -1,6 +1,5 @@
 """Tests for working with Aeromancy Artifacts."""
 
-
 import pytest
 
 from aeromancy.artifacts import (


### PR DESCRIPTION
**tl;dr**: You can now use `--tags tag1,tag2` when launching tasks, fixes #20. All tags in the list will be associated with all launched tasks.

This PR also includes some overdue Ruff and pre-commit updates, addressing their changes. Got a little carried away -- ideally, these would probably be a separate PR.