### PR TITLE
Fix EXTRA_DEBIAN_PACKAGES quoting bug

### DIFF
--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -104,7 +104,6 @@ def build_docker(
         "project=.",
     ]
     if extra_debian_packages:
-        # Format with !r (repr()) to automatically handle spaces and escaping.
         build_arg = f"EXTRA_DEBIAN_PACKAGES={' '.join(extra_debian_packages)!r}"
         docker_commmand_pieces.extend(("--build-arg", build_arg))
     if quiet:

--- a/src/aeromancy/runner.py
+++ b/src/aeromancy/runner.py
@@ -104,7 +104,7 @@ def build_docker(
         "project=.",
     ]
     if extra_debian_packages:
-        build_arg = f"EXTRA_DEBIAN_PACKAGES={' '.join(extra_debian_packages)!r}"
+        build_arg = f"EXTRA_DEBIAN_PACKAGES={' '.join(extra_debian_packages)}"
         docker_commmand_pieces.extend(("--build-arg", build_arg))
     if quiet:
         docker_commmand_pieces.append("--quiet")


### PR DESCRIPTION
Previously, this needed extra quotes since it was run as a shell command. Since command arguments are [now passed](https://github.com/quant-aq/aeromancy/commit/cc10136e051594f28e851d0a546736c9e89e6bf4#diff-43c5cd822d8abfa9997062f4e4cd911ab19194fb539176e71bb3798fecf70f0fL50-R54) as an array of strings, the extra quoting combined with the quotes from `repr()` result in some bizarre things like:

    --build-arg 'EXTRA_DEBIAN_PACKAGES="'"'"'pkg1 pkg2'"'"'"'